### PR TITLE
Update recommended ruby version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more about OneOps see <http://www.oneops.com>.
 Pre-requisites
 --------------
 
-The version of Ruby recommended to run the OneOps CLI is [RVM](http://rvm.io) with latest ruby `v1.9.3` installed from there.
+The version of Ruby recommended to run the OneOps CLI is [RVM](http://rvm.io) with latest ruby `v2.1.1` installed from there.
 
 
 Install


### PR DESCRIPTION
When using 1.9.3 not all the dependencies can be installed. I also think https://github.com/oneops/cli/pull/24 needs to be merged though, because I had to make those changes locally to get it to run.